### PR TITLE
Add date-range filter to file search

### DIFF
--- a/src/main/java/com/bytedompteur/documentfinder/fulltextsearchengine/adapter/in/FulltextSearchService.java
+++ b/src/main/java/com/bytedompteur/documentfinder/fulltextsearchengine/adapter/in/FulltextSearchService.java
@@ -3,6 +3,7 @@ package com.bytedompteur.documentfinder.fulltextsearchengine.adapter.in;
 import reactor.core.publisher.Flux;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 
 public interface FulltextSearchService {
 
@@ -24,7 +25,7 @@ public interface FulltextSearchService {
 
   Flux<Path> getCurrentPathProcessed();
 
-  Flux<SearchResult> findFilesWithNamesOrContentMatching(CharSequence charSequence);
+  Flux<SearchResult> findFilesWithNamesOrContentMatching(CharSequence charSequence, LocalDate updatedFrom, LocalDate updatedTo);
 
   Flux<SearchResult> findLastUpdated();
 

--- a/src/main/java/com/bytedompteur/documentfinder/fulltextsearchengine/core/FulltextSearchServiceImpl.java
+++ b/src/main/java/com/bytedompteur/documentfinder/fulltextsearchengine/core/FulltextSearchServiceImpl.java
@@ -7,6 +7,7 @@ import reactor.core.publisher.Flux;
 
 import jakarta.inject.Inject;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @RequiredArgsConstructor(onConstructor = @__(@Inject))
@@ -51,8 +52,8 @@ public class FulltextSearchServiceImpl implements FulltextSearchService {
   }
 
   @Override
-  public Flux<SearchResult> findFilesWithNamesOrContentMatching(CharSequence charSequence) {
-    return indexRepository.findByFileNameOrContent(charSequence);
+  public Flux<SearchResult> findFilesWithNamesOrContentMatching(CharSequence charSequence, LocalDate updatedFrom, LocalDate updatedTo) {
+    return indexRepository.findByFileNameOrContent(charSequence, updatedFrom, updatedTo);
   }
 
   @Override

--- a/src/main/java/com/bytedompteur/documentfinder/fulltextsearchengine/core/IndexRepository.java
+++ b/src/main/java/com/bytedompteur/documentfinder/fulltextsearchengine/core/IndexRepository.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -86,6 +88,10 @@ public class IndexRepository {
             UPDATED_FIELD_NAME,
             toLuceneDate(value.updated())
         );
+        var updatedRangeField = new LongPoint(
+            UPDATED_FIELD_NAME,
+            toLuceneDate(value.updated())
+        );
         var updatedDisplayField = new StringField(
             UPDATED_DISPLAY_FIELD_NAME,
             DATE_FORMATTER.format(value.updated().atZone(ZoneId.systemDefault())),
@@ -100,6 +106,7 @@ public class IndexRepository {
         document.add(createdField);
         document.add(createdDisplayField);
         document.add(updatedField);
+        document.add(updatedRangeField);
         document.add(updatedDisplayField);
 
         log.debug("Adding entry for '{}'", pathString);
@@ -116,12 +123,14 @@ public class IndexRepository {
     }
 
 
-    public Flux<SearchResult> findByFileNameOrContent(CharSequence searchText) {
+    public Flux<SearchResult> findByFileNameOrContent(CharSequence searchText, LocalDate updatedFrom, LocalDate updatedTo) {
         Flux<SearchResult> result = Flux.empty();
-        if (isNotBlank(searchText) && (searchText.length() >= MINIMUM_LENGTH_FOR_SEARCH || NUMERIC.matcher(searchText).matches())) {
+        var hasSearchText = isNotBlank(searchText) && (searchText.length() >= MINIMUM_LENGTH_FOR_SEARCH || NUMERIC.matcher(searchText).matches());
+        var hasDateRange = updatedFrom != null || updatedTo != null;
+        if (hasSearchText || hasDateRange) {
             try {
-                var searchTextString = searchText.toString();
-                Query query = createQueryFromParseSearchText(searchTextString);
+                var searchTextString = searchText == null ? "" : searchText.toString();
+                Query query = createQuery(hasSearchText ? searchTextString : null, updatedFrom, updatedTo);
                 result = executeSearch(query, MAX_RESULT_LIMIT);
             } catch (ParseException e) {
                 // IGNORE - this error will be thrown search text could not be parsed by lucene.
@@ -164,6 +173,17 @@ public class IndexRepository {
             .doOnCancel(() -> closeReader(indexSearcher));
     }
 
+    private Query createQuery(String searchText, LocalDate updatedFrom, LocalDate updatedTo) throws ParseException {
+        var builder = new BooleanQuery.Builder();
+        if (isNotBlank(searchText)) {
+            builder.add(createQueryFromParseSearchText(searchText), BooleanClause.Occur.MUST);
+        }
+        if (updatedFrom != null || updatedTo != null) {
+            builder.add(LongPoint.newRangeQuery(UPDATED_FIELD_NAME, toLowerLuceneBound(updatedFrom), toUpperLuceneBound(updatedTo)), BooleanClause.Occur.MUST);
+        }
+        return builder.build();
+    }
+
     private Query createQueryFromParseSearchText(String searchText) throws ParseException {
         Query query;
         var parser = new MultiFieldQueryParser(new String[]{PATH_FIELD_NAME, PAYLOAD_FIELD_NAME_GERMAN, PAYLOAD_FIELD_NAME_ENGLISH}, new StandardAnalyzer());
@@ -171,6 +191,14 @@ public class IndexRepository {
         parser.setAllowLeadingWildcard(true);
         query = parser.parse(searchText);
         return query;
+    }
+
+    private static long toLowerLuceneBound(LocalDate date) {
+        return date == null ? Long.MIN_VALUE : toLuceneDate(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
+    }
+
+    private static long toUpperLuceneBound(LocalDate date) {
+        return date == null ? Long.MAX_VALUE : toLuceneDate(date.atTime(LocalTime.MAX).atZone(ZoneId.systemDefault()).toInstant());
     }
 
     protected Flux<SearchResult> createSearchResultFlux(IndexSearcher indexSearcher, ScoreDoc[] scoreDocs) {

--- a/src/main/java/com/bytedompteur/documentfinder/ui/mainwindow/DateRangeFilterPopup.java
+++ b/src/main/java/com/bytedompteur/documentfinder/ui/mainwindow/DateRangeFilterPopup.java
@@ -1,0 +1,196 @@
+package com.bytedompteur.documentfinder.ui.mainwindow;
+
+import com.bytedompteur.documentfinder.ui.mainwindow.dagger.MainWindowScope;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.CustomMenuItem;
+import javafx.scene.control.DatePicker;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+
+import jakarta.inject.Inject;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+@MainWindowScope
+public class DateRangeFilterPopup extends ContextMenu {
+
+    public enum DateRangePreset {
+        ANY_TIME("Any time"),
+        TODAY("Today"),
+        LAST_7_DAYS("Last 7 days"),
+        LAST_30_DAYS("Last 30 days"),
+        THIS_YEAR("This year"),
+        CUSTOM("Custom range…");
+
+        private final String label;
+
+        DateRangePreset(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+    }
+
+    private static final DateTimeFormatter CHIP_DATE_FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy", Locale.US);
+
+    private final ComboBox<DateRangePreset> presetComboBox = new ComboBox<>();
+    private final DatePicker fromDatePicker = new DatePicker();
+    private final DatePicker toDatePicker = new DatePicker();
+    private final Button applyButton = new Button("Apply");
+    private final Button clearButton = new Button("Clear");
+
+    private DateRangePreset appliedPreset = DateRangePreset.ANY_TIME;
+    private LocalDate appliedFrom;
+    private LocalDate appliedTo;
+    private Runnable onFilterApplied = () -> {
+    };
+
+    @Inject
+    public DateRangeFilterPopup() {
+        presetComboBox.getItems().setAll(DateRangePreset.values());
+        presetComboBox.setValue(DateRangePreset.ANY_TIME);
+        presetComboBox.setMaxWidth(Double.MAX_VALUE);
+        presetComboBox.valueProperty().addListener((observable, oldValue, newValue) -> handlePresetSelected());
+
+        fromDatePicker.setPromptText("From");
+        toDatePicker.setPromptText("To");
+        fromDatePicker.setVisible(false);
+        fromDatePicker.setManaged(false);
+        toDatePicker.setVisible(false);
+        toDatePicker.setManaged(false);
+
+        applyButton.setOnAction(event -> handleApply());
+        clearButton.setOnAction(event -> handleClear());
+        ButtonBar.setButtonData(clearButton, ButtonBar.ButtonData.LEFT);
+        ButtonBar.setButtonData(applyButton, ButtonBar.ButtonData.OK_DONE);
+        var buttonBar = new ButtonBar();
+        buttonBar.getButtons().addAll(clearButton, applyButton);
+
+        var customDatesBox = new HBox(5.0, fromDatePicker, toDatePicker);
+
+        var content = new VBox(10.0, presetComboBox, customDatesBox, buttonBar);
+        content.setPadding(new Insets(10.0));
+        content.setPrefWidth(260.0);
+
+        var menuItem = new CustomMenuItem(content);
+        menuItem.setHideOnClick(false);
+        getItems().add(menuItem);
+    }
+
+    public void setOnFilterApplied(Runnable onFilterApplied) {
+        this.onFilterApplied = onFilterApplied == null ? () -> {
+        } : onFilterApplied;
+    }
+
+    public LocalDate getSelectedFrom() {
+        return appliedFrom;
+    }
+
+    public LocalDate getSelectedTo() {
+        return appliedTo;
+    }
+
+    public boolean isActive() {
+        return appliedFrom != null || appliedTo != null;
+    }
+
+    public String getActiveFilterDescription() {
+        if (appliedPreset != DateRangePreset.CUSTOM) {
+            return appliedPreset.toString();
+        }
+        if (appliedFrom != null && appliedTo != null) {
+            return CHIP_DATE_FORMATTER.format(appliedFrom) + " – " + CHIP_DATE_FORMATTER.format(appliedTo);
+        }
+        if (appliedFrom != null) {
+            return "From " + CHIP_DATE_FORMATTER.format(appliedFrom);
+        }
+        if (appliedTo != null) {
+            return "Until " + CHIP_DATE_FORMATTER.format(appliedTo);
+        }
+        return DateRangePreset.ANY_TIME.toString();
+    }
+
+    public void clear() {
+        fromDatePicker.setValue(null);
+        toDatePicker.setValue(null);
+        presetComboBox.setValue(DateRangePreset.ANY_TIME);
+    }
+
+    // For testing
+
+    protected ComboBox<DateRangePreset> getPresetComboBox() {
+        return presetComboBox;
+    }
+
+    protected DatePicker getFromDatePicker() {
+        return fromDatePicker;
+    }
+
+    protected DatePicker getToDatePicker() {
+        return toDatePicker;
+    }
+
+    protected Button getApplyButton() {
+        return applyButton;
+    }
+
+    protected Button getClearButton() {
+        return clearButton;
+    }
+
+    private void handlePresetSelected() {
+        var preset = presetComboBox.getValue();
+        var isCustom = preset == DateRangePreset.CUSTOM;
+        fromDatePicker.setVisible(isCustom);
+        fromDatePicker.setManaged(isCustom);
+        toDatePicker.setVisible(isCustom);
+        toDatePicker.setManaged(isCustom);
+
+        if (!isCustom) {
+            var range = toRange(preset);
+            applyPreset(preset, range[0], range[1]);
+            hide();
+        }
+    }
+
+    private void handleApply() {
+        var from = fromDatePicker.getValue();
+        var to = toDatePicker.getValue();
+        if (from == null && to == null) {
+            clear();
+            return;
+        }
+        applyPreset(DateRangePreset.CUSTOM, from, to);
+        hide();
+    }
+
+    private void handleClear() {
+        clear();
+    }
+
+    private void applyPreset(DateRangePreset preset, LocalDate from, LocalDate to) {
+        this.appliedPreset = preset;
+        this.appliedFrom = from;
+        this.appliedTo = to;
+        onFilterApplied.run();
+    }
+
+    private static LocalDate[] toRange(DateRangePreset preset) {
+        var today = LocalDate.now();
+        return switch (preset) {
+            case TODAY -> new LocalDate[]{today, today};
+            case LAST_7_DAYS -> new LocalDate[]{today.minusDays(6), today};
+            case LAST_30_DAYS -> new LocalDate[]{today.minusDays(29), today};
+            case THIS_YEAR -> new LocalDate[]{LocalDate.of(today.getYear(), 1, 1), today};
+            case ANY_TIME, CUSTOM -> new LocalDate[]{null, null};
+        };
+    }
+}

--- a/src/main/java/com/bytedompteur/documentfinder/ui/mainwindow/MainWindowController.java
+++ b/src/main/java/com/bytedompteur/documentfinder/ui/mainwindow/MainWindowController.java
@@ -8,6 +8,7 @@ import com.bytedompteur.documentfinder.ui.mainwindow.dagger.MainWindowScope;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.geometry.Side;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -15,6 +16,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.Disposable;
 import reactor.core.publisher.Mono;
@@ -40,6 +42,7 @@ public class MainWindowController implements FxController {
     private final FulltextSearchService fulltextSearchService;
     private final FileSystemAdapter fileSystemAdapter;
     private final WindowManager windowManager;
+    private final DateRangeFilterPopup dateRangeFilterPopup;
     private final String applicationHomeDirectory;
     private final AtomicBoolean ignoreNextSearchAsYouTypeKeyEvent = new AtomicBoolean(false);
 
@@ -50,6 +53,7 @@ public class MainWindowController implements FxController {
         FulltextSearchService fulltextSearchService,
         FileSystemAdapter fileSystemAdapter,
         WindowManager windowManager,
+        DateRangeFilterPopup dateRangeFilterPopup,
         @Named("applicationHomeDirectory") String applicationHomeDirectory
     ) {
         this.searchResultTable = searchResultTable;
@@ -57,6 +61,7 @@ public class MainWindowController implements FxController {
         this.fulltextSearchService = fulltextSearchService;
         this.fileSystemAdapter = fileSystemAdapter;
         this.windowManager = windowManager;
+        this.dateRangeFilterPopup = dateRangeFilterPopup;
         this.applicationHomeDirectory = applicationHomeDirectory;
     }
 
@@ -68,6 +73,12 @@ public class MainWindowController implements FxController {
 
     @FXML
     public Button findLastUpdatedButton;
+
+    @FXML
+    public Button dateRangeFilterButton;
+
+    @FXML
+    public Label activeDateFilterChip;
 
     @FXML
     public Node mainWindowResultTable;
@@ -125,7 +136,7 @@ public class MainWindowController implements FxController {
                 disposable = Mono
                     .delay(Duration.ofMillis(300))
                     .subscribe(it -> {
-                        if (searchTextField.getCharacters().isEmpty()) {
+                        if (searchTextField.getCharacters().isEmpty() && !dateRangeFilterPopup.isActive()) {
                             clearSearchResults();
                         } else {
                             searchForFilesMatchingSearchText();
@@ -162,8 +173,12 @@ public class MainWindowController implements FxController {
         Mono
             .just(searchTextField.getCharacters())
             .doOnEach(it -> clearSearchResults())
-            .filter(it -> !it.isEmpty())
-            .flatMapMany(fulltextSearchService::findFilesWithNamesOrContentMatching)
+            .filter(it -> !it.isEmpty() || dateRangeFilterPopup.isActive())
+            .flatMapMany(it -> fulltextSearchService.findFilesWithNamesOrContentMatching(
+                it,
+                dateRangeFilterPopup.getSelectedFrom(),
+                dateRangeFilterPopup.getSelectedTo()
+            ))
             .filter(it -> it.getPath().toFile().exists()) // Exclude if file does not exist
             .map(it -> SearchResult.build(
                 it.getPath(),
@@ -195,6 +210,25 @@ public class MainWindowController implements FxController {
     }
 
     @SuppressWarnings("java:S1172")
+    public void handleDateRangeFilterButtonClick(ActionEvent ignore) {
+        dateRangeFilterPopup.show(dateRangeFilterButton, Side.BOTTOM, 0, 0);
+    }
+
+    @SuppressWarnings("java:S1172")
+    public void handleActiveDateFilterChipClick(MouseEvent ignore) {
+        dateRangeFilterPopup.clear();
+    }
+
+    private void updateActiveDateFilterChip() {
+        var active = dateRangeFilterPopup.isActive();
+        activeDateFilterChip.setVisible(active);
+        activeDateFilterChip.setManaged(active);
+        if (active) {
+            activeDateFilterChip.setText(dateRangeFilterPopup.getActiveFilterDescription());
+        }
+    }
+
+    @SuppressWarnings("java:S1172")
     public void handleOpenLogDirectoryAction(ActionEvent ignore) {
         fileSystemAdapter.openInOperatingSystem(Path.of(applicationHomeDirectory));
     }
@@ -202,6 +236,10 @@ public class MainWindowController implements FxController {
     @FXML
     public void initialize() {
         clearSearchResults();
+        dateRangeFilterPopup.setOnFilterApplied(() -> {
+            updateActiveDateFilterChip();
+            searchForFilesMatchingSearchText();
+        });
     }
 
     @Override

--- a/src/main/resources/fxml/MainWindow.fxml
+++ b/src/main/resources/fxml/MainWindow.fxml
@@ -45,6 +45,20 @@
                                 <Tooltip text="Clear search result"/>
                             </tooltip>
                         </Button>
+                        <Button fx:id="dateRangeFilterButton" mnemonicParsing="false"
+                                onAction="#handleDateRangeFilterButtonClick" HBox.hgrow="NEVER">
+                            <styleClass>
+                                <String fx:value="flat"/>
+                                <String fx:value="button-icon"/>
+                                <String fx:value="button-circle"/>
+                            </styleClass>
+                            <graphic>
+                                <MaterialIconView glyphName="DATE_RANGE" size="25"/>
+                            </graphic>
+                            <tooltip>
+                                <Tooltip text="Filter by last modified date"/>
+                            </tooltip>
+                        </Button>
                         <Button fx:id="findLastUpdatedButton" layoutX="432.0" layoutY="10.0" mnemonicParsing="false"
                                 onAction="#handleFindLastUpdatedButtonClick">
                             <styleClass>
@@ -75,7 +89,20 @@
                         </Button>
                     </children>
                     <padding>
-                        <Insets bottom="25.0" left="20.0" right="20.0" top="10.0"/>
+                        <Insets bottom="10.0" left="20.0" right="20.0" top="10.0"/>
+                    </padding>
+                </HBox>
+                <HBox fx:id="mainWindowActiveFiltersBar" spacing="5.0" BorderPane.alignment="CENTER">
+                    <children>
+                        <Label fx:id="activeDateFilterChip" onMouseClicked="#handleActiveDateFilterChipClick"
+                               managed="false" visible="false" contentDisplay="RIGHT" styleClass="accent">
+                            <graphic>
+                                <MaterialIconView glyphName="CANCEL" size="14"/>
+                            </graphic>
+                        </Label>
+                    </children>
+                    <padding>
+                        <Insets bottom="15.0" left="20.0" right="20.0" top="0.0"/>
                     </padding>
                 </HBox>
             </children>

--- a/src/test/java/com/bytedompteur/documentfinder/fulltextsearchengine/core/IndexRepositoryIntegrationTest.java
+++ b/src/test/java/com/bytedompteur/documentfinder/fulltextsearchengine/core/IndexRepositoryIntegrationTest.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -96,7 +98,7 @@ class IndexRepositoryIntegrationTest {
         indexWriter.close();
 
         // Act
-        var result = StepVerifier.create(sut.findByFileNameOrContent(searchText));
+        var result = StepVerifier.create(sut.findByFileNameOrContent(searchText, null, null));
 
         // Assert
         result.expectNextCount(numberOfExpectedResults).verifyComplete();
@@ -203,7 +205,7 @@ class IndexRepositoryIntegrationTest {
 
 
         // Act
-        var firstStep = StepVerifier.create(sut.findByFileNameOrContent("pdf"));
+        var firstStep = StepVerifier.create(sut.findByFileNameOrContent("pdf", null, null));
 
         // Assert
         firstStep
@@ -211,6 +213,152 @@ class IndexRepositoryIntegrationTest {
             .assertNext(it -> assertThat(it.getPath()).isEqualTo(Path.of("/a/3.pdf")))
             .assertNext(it -> assertThat(it.getPath()).isEqualTo(Path.of("/a/2.pdf")))
             .assertNext(it -> assertThat(it.getPath()).isEqualTo(Path.of("/a/1.pdf")))
+            .verifyComplete();
+    }
+
+    @Test
+    void findByFileNameOrContent_excludesFilesOutsideDateRange_whenUpdatedFromAndUpdatedToGiven() throws IOException {
+        // Arrange
+        when(mockedIndexSearchFactory.build()).thenAnswer(param -> new IndexSearcher(DirectoryReader.open(fsDirectory)));
+
+        var zone = ZoneId.systemDefault();
+        var inRange = new FileRecord(Path.of("/a/in-range.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 15).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 6, 15).atTime(12, 0).atZone(zone).toInstant());
+        var tooEarly = new FileRecord(Path.of("/a/too-early.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 1).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 6, 1).atTime(12, 0).atZone(zone).toInstant());
+        var tooLate = new FileRecord(Path.of("/a/too-late.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 7, 1).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 7, 1).atTime(12, 0).atZone(zone).toInstant());
+
+        for (FileRecord record : List.of(inRange, tooEarly, tooLate)) {
+            sut.save(record);
+        }
+        indexWriter.flush();
+        indexWriter.commit();
+        indexWriter.close();
+
+        // Act
+        var result = StepVerifier.create(sut.findByFileNameOrContent("pdf", LocalDate.of(2024, 6, 10), LocalDate.of(2024, 6, 20)));
+
+        // Assert
+        result
+            .assertNext(it -> assertThat(it.getPath()).isEqualTo(Path.of("/a/in-range.pdf")))
+            .verifyComplete();
+    }
+
+    @Test
+    void findByFileNameOrContent_includesFilesUpdatedAtStartAndEndOfBoundaryDay_whenUpdatedFromAndUpdatedToGiven() throws IOException {
+        // Arrange
+        when(mockedIndexSearchFactory.build()).thenAnswer(param -> new IndexSearcher(DirectoryReader.open(fsDirectory)));
+
+        var zone = ZoneId.systemDefault();
+        var atStartOfLowerBoundDay = new FileRecord(Path.of("/a/start.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 10).atStartOfDay(zone).toInstant(),
+            LocalDate.of(2024, 6, 10).atStartOfDay(zone).toInstant());
+        var atEndOfUpperBoundDay = new FileRecord(Path.of("/a/end.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 20).atTime(23, 59, 59).atZone(zone).toInstant(),
+            LocalDate.of(2024, 6, 20).atTime(23, 59, 59).atZone(zone).toInstant());
+
+        for (FileRecord record : List.of(atStartOfLowerBoundDay, atEndOfUpperBoundDay)) {
+            sut.save(record);
+        }
+        indexWriter.flush();
+        indexWriter.commit();
+        indexWriter.close();
+
+        // Act
+        var result = StepVerifier.create(sut.findByFileNameOrContent("pdf", LocalDate.of(2024, 6, 10), LocalDate.of(2024, 6, 20)));
+
+        // Assert
+        result.expectNextCount(2).verifyComplete();
+    }
+
+    @Test
+    void findByFileNameOrContent_returnsOnlyFilesFromUpdatedFromOnwards_whenOnlyUpdatedFromGiven() throws IOException {
+        // Arrange
+        when(mockedIndexSearchFactory.build()).thenAnswer(param -> new IndexSearcher(DirectoryReader.open(fsDirectory)));
+
+        var zone = ZoneId.systemDefault();
+        var before = new FileRecord(Path.of("/a/before.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 1).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 6, 1).atTime(12, 0).atZone(zone).toInstant());
+        var after = new FileRecord(Path.of("/a/after.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 30).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 6, 30).atTime(12, 0).atZone(zone).toInstant());
+
+        for (FileRecord record : List.of(before, after)) {
+            sut.save(record);
+        }
+        indexWriter.flush();
+        indexWriter.commit();
+        indexWriter.close();
+
+        // Act
+        var result = StepVerifier.create(sut.findByFileNameOrContent("pdf", LocalDate.of(2024, 6, 10), null));
+
+        // Assert
+        result
+            .assertNext(it -> assertThat(it.getPath()).isEqualTo(Path.of("/a/after.pdf")))
+            .verifyComplete();
+    }
+
+    @Test
+    void findByFileNameOrContent_returnsOnlyFilesUpToUpdatedTo_whenOnlyUpdatedToGiven() throws IOException {
+        // Arrange
+        when(mockedIndexSearchFactory.build()).thenAnswer(param -> new IndexSearcher(DirectoryReader.open(fsDirectory)));
+
+        var zone = ZoneId.systemDefault();
+        var before = new FileRecord(Path.of("/a/before.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 1).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 6, 1).atTime(12, 0).atZone(zone).toInstant());
+        var after = new FileRecord(Path.of("/a/after.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 30).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 6, 30).atTime(12, 0).atZone(zone).toInstant());
+
+        for (FileRecord record : List.of(before, after)) {
+            sut.save(record);
+        }
+        indexWriter.flush();
+        indexWriter.commit();
+        indexWriter.close();
+
+        // Act
+        var result = StepVerifier.create(sut.findByFileNameOrContent("pdf", null, LocalDate.of(2024, 6, 10)));
+
+        // Assert
+        result
+            .assertNext(it -> assertThat(it.getPath()).isEqualTo(Path.of("/a/before.pdf")))
+            .verifyComplete();
+    }
+
+    @Test
+    void findByFileNameOrContent_returnsFilesInDateRange_whenSearchTextIsBlank() throws IOException {
+        // Arrange
+        when(mockedIndexSearchFactory.build()).thenAnswer(param -> new IndexSearcher(DirectoryReader.open(fsDirectory)));
+
+        var zone = ZoneId.systemDefault();
+        var inRange = new FileRecord(Path.of("/a/in-range.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 6, 15).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 6, 15).atTime(12, 0).atZone(zone).toInstant());
+        var tooLate = new FileRecord(Path.of("/a/too-late.pdf"), new StringReader(" pdf "), Locale.ENGLISH,
+            LocalDate.of(2024, 7, 1).atTime(12, 0).atZone(zone).toInstant(),
+            LocalDate.of(2024, 7, 1).atTime(12, 0).atZone(zone).toInstant());
+
+        for (FileRecord record : List.of(inRange, tooLate)) {
+            sut.save(record);
+        }
+        indexWriter.flush();
+        indexWriter.commit();
+        indexWriter.close();
+
+        // Act
+        var result = StepVerifier.create(sut.findByFileNameOrContent("", LocalDate.of(2024, 6, 10), LocalDate.of(2024, 6, 20)));
+
+        // Assert
+        result
+            .assertNext(it -> assertThat(it.getPath()).isEqualTo(Path.of("/a/in-range.pdf")))
             .verifyComplete();
     }
 

--- a/src/test/java/com/bytedompteur/documentfinder/fulltextsearchengine/core/IndexRepositoryTest.java
+++ b/src/test/java/com/bytedompteur/documentfinder/fulltextsearchengine/core/IndexRepositoryTest.java
@@ -18,6 +18,7 @@ import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -140,18 +141,18 @@ class IndexRepositoryTest {
   }
 
   @Test
-  void findByFileNameOrContent_returnsEmptyFlux_whenSearchTextIsNull() {
+  void findByFileNameOrContent_returnsEmptyFlux_whenSearchTextIsNullAndNoDateRangeGiven() {
     // Act
-    var result = StepVerifier.create(sut.findByFileNameOrContent(null));
+    var result = StepVerifier.create(sut.findByFileNameOrContent(null, null, null));
 
     // Assert
     result.verifyComplete();
   }
 
   @Test
-  void findByFileNameOrContent_returnsEmptyFlux_whenSearchTextIsEmpty() {
+  void findByFileNameOrContent_returnsEmptyFlux_whenSearchTextIsEmptyAndNoDateRangeGiven() {
     // Act
-    var result = StepVerifier.create(sut.findByFileNameOrContent("    "));
+    var result = StepVerifier.create(sut.findByFileNameOrContent("    ", null, null));
 
     // Assert
     result.verifyComplete();
@@ -169,10 +170,41 @@ class IndexRepositoryTest {
       .thenThrow(new IOException("Expected exception from unit test"));
 
     // Act
-    var result = StepVerifier.create(sut.findByFileNameOrContent("a search text"));
+    var result = StepVerifier.create(sut.findByFileNameOrContent("a search text", null, null));
 
     // Assert
     result.verifyComplete();
+  }
+
+  @Test
+  void findByFileNameOrContent_searches_whenSearchTextIsEmptyButDateRangeIsGiven() throws IOException {
+    // Arrange
+    Mockito
+      .when(mockedIndexSearcher.storedFields()).thenReturn(mockedStoredFields);
+    Mockito
+      .when(mockedStoredFields.document(anyInt(), anySet()))
+      .thenReturn(new Document());
+
+    Mockito
+      .when(mockedIndexSearchFactory.build())
+      .thenReturn(mockedIndexSearcher);
+
+    var scoreDocs = new ScoreDoc[]{new ScoreDoc(1, 1.0F)};
+    Mockito
+      .when(mockedIndexSearcher.search(any(), anyInt(), any(Sort.class)))
+      .thenReturn(new TopFieldDocs(new TotalHits(1L, TotalHits.Relation.EQUAL_TO), scoreDocs, new SortField[0]));
+
+    Mockito
+      .when(mockedIndexSearcher.getIndexReader())
+      .thenReturn(new MultiReader());
+
+    // Act
+    var result = StepVerifier.create(sut.findByFileNameOrContent("", LocalDate.now().minusDays(7), LocalDate.now()));
+
+    // Assert
+    result
+      .expectNextCount(1)
+      .verifyComplete();
   }
 
   @Test
@@ -208,7 +240,7 @@ class IndexRepositoryTest {
       .thenReturn(new MultiReader());
 
     // Act
-    var result = StepVerifier.create(sut.findByFileNameOrContent("a search text"));
+    var result = StepVerifier.create(sut.findByFileNameOrContent("a search text", null, null));
 
     // Assert
     result

--- a/src/test/java/com/bytedompteur/documentfinder/ui/mainwindow/DateRangeFilterPopupTest.java
+++ b/src/test/java/com/bytedompteur/documentfinder/ui/mainwindow/DateRangeFilterPopupTest.java
@@ -1,0 +1,138 @@
+package com.bytedompteur.documentfinder.ui.mainwindow;
+
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(ApplicationExtension.class)
+class DateRangeFilterPopupTest {
+
+  private DateRangeFilterPopup sut;
+
+  @Start
+  void start(Stage stage) {
+    sut = new DateRangeFilterPopup();
+  }
+
+  @Test
+  void isActive_returnsFalse_whenNothingWasSelected() {
+    // Assert
+    assertThat(sut.isActive()).isFalse();
+    assertThat(sut.getSelectedFrom()).isNull();
+    assertThat(sut.getSelectedTo()).isNull();
+  }
+
+  @Test
+  void selectingPreset_appliesTodayAsFromAndTo_whenTodayPresetSelected(FxRobot robot) {
+    // Arrange
+    var today = LocalDate.now();
+    var applied = new boolean[]{false};
+    sut.setOnFilterApplied(() -> applied[0] = true);
+
+    // Act
+    robot.interact(() -> sut.getPresetComboBox().setValue(DateRangeFilterPopup.DateRangePreset.TODAY));
+
+    // Assert
+    assertThat(sut.isActive()).isTrue();
+    assertThat(sut.getSelectedFrom()).isEqualTo(today);
+    assertThat(sut.getSelectedTo()).isEqualTo(today);
+    assertThat(applied[0]).isTrue();
+  }
+
+  @Test
+  void selectingPreset_appliesLast7Days_whenLast7DaysPresetSelected(FxRobot robot) {
+    // Arrange
+    var today = LocalDate.now();
+
+    // Act
+    robot.interact(() -> sut.getPresetComboBox().setValue(DateRangeFilterPopup.DateRangePreset.LAST_7_DAYS));
+
+    // Assert
+    assertThat(sut.getSelectedFrom()).isEqualTo(today.minusDays(6));
+    assertThat(sut.getSelectedTo()).isEqualTo(today);
+  }
+
+  @Test
+  void selectingCustomPreset_revealsDatePickersAndDoesNotApplyYet_whenCustomPresetSelected(FxRobot robot) {
+    // Arrange
+    var applied = new boolean[]{false};
+    sut.setOnFilterApplied(() -> applied[0] = true);
+
+    // Act
+    robot.interact(() -> sut.getPresetComboBox().setValue(DateRangeFilterPopup.DateRangePreset.CUSTOM));
+
+    // Assert
+    assertThat(sut.getFromDatePicker().isVisible()).isTrue();
+    assertThat(sut.getToDatePicker().isVisible()).isTrue();
+    assertThat(sut.isActive()).isFalse();
+    assertThat(applied[0]).isFalse();
+  }
+
+  @Test
+  void clickingApply_appliesCustomDates_whenCustomPresetSelectedWithBothDatesSet(FxRobot robot) {
+    // Arrange
+    var from = LocalDate.of(2024, 6, 1);
+    var to = LocalDate.of(2024, 6, 30);
+    robot.interact(() -> {
+      sut.getPresetComboBox().setValue(DateRangeFilterPopup.DateRangePreset.CUSTOM);
+      sut.getFromDatePicker().setValue(from);
+      sut.getToDatePicker().setValue(to);
+    });
+
+    // Act
+    robot.interact(() -> sut.getApplyButton().fire());
+
+    // Assert
+    assertThat(sut.isActive()).isTrue();
+    assertThat(sut.getSelectedFrom()).isEqualTo(from);
+    assertThat(sut.getSelectedTo()).isEqualTo(to);
+    assertThat(sut.getActiveFilterDescription()).contains("1 Jun 2024").contains("30 Jun 2024");
+  }
+
+  @Test
+  void clickingApply_clearsFilter_whenCustomPresetSelectedWithNoDatesSet(FxRobot robot) {
+    // Arrange
+    robot.interact(() -> sut.getPresetComboBox().setValue(DateRangeFilterPopup.DateRangePreset.CUSTOM));
+
+    // Act
+    robot.interact(() -> sut.getApplyButton().fire());
+
+    // Assert
+    assertThat(sut.isActive()).isFalse();
+    assertThat(sut.getPresetComboBox().getValue()).isEqualTo(DateRangeFilterPopup.DateRangePreset.ANY_TIME);
+  }
+
+  @Test
+  void clear_resetsToAnyTime_whenAPresetWasApplied(FxRobot robot) {
+    // Arrange
+    robot.interact(() -> sut.getPresetComboBox().setValue(DateRangeFilterPopup.DateRangePreset.LAST_30_DAYS));
+    assertThat(sut.isActive()).isTrue();
+
+    // Act
+    robot.interact(() -> sut.clear());
+
+    // Assert
+    assertThat(sut.isActive()).isFalse();
+    assertThat(sut.getSelectedFrom()).isNull();
+    assertThat(sut.getSelectedTo()).isNull();
+  }
+
+  @Test
+  void clickingClearButton_resetsToAnyTime_whenAPresetWasApplied(FxRobot robot) {
+    // Arrange
+    robot.interact(() -> sut.getPresetComboBox().setValue(DateRangeFilterPopup.DateRangePreset.THIS_YEAR));
+
+    // Act
+    robot.interact(() -> sut.getClearButton().fire());
+
+    // Assert
+    assertThat(sut.isActive()).isFalse();
+  }
+}

--- a/src/test/java/com/bytedompteur/documentfinder/ui/mainwindow/MainWindowControllerTest.java
+++ b/src/test/java/com/bytedompteur/documentfinder/ui/mainwindow/MainWindowControllerTest.java
@@ -14,10 +14,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
+import reactor.core.publisher.Flux;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(ApplicationExtension.class)
@@ -26,10 +29,14 @@ class MainWindowControllerTest {
     private static final String APPLICATION_HOME_DIR = "/test/home";
     private MainWindowController sut;
     private FileSystemAdapter mockedFileSystemAdapter;
+    private FulltextSearchService mockedFulltextSearchService;
+    private DateRangeFilterPopup mockedDateRangeFilterPopup;
 
     @Start
     void start(Stage stage) {
         mockedFileSystemAdapter = mock(FileSystemAdapter.class);
+        mockedFulltextSearchService = mock(FulltextSearchService.class);
+        mockedDateRangeFilterPopup = mock(DateRangeFilterPopup.class);
         var mockedSearchResultTableController = mock(SearchResultTableController.class);
         var mockedProgressBarController = mock(AnalyzeFilesProgressBarController.class);
 
@@ -39,9 +46,10 @@ class MainWindowControllerTest {
         sut = new MainWindowController(
             mockedSearchResultTableController,
             mockedProgressBarController,
-            mock(FulltextSearchService.class),
+            mockedFulltextSearchService,
             mockedFileSystemAdapter,
             mock(WindowManager.class),
+            mockedDateRangeFilterPopup,
             APPLICATION_HOME_DIR
         );
 
@@ -67,5 +75,34 @@ class MainWindowControllerTest {
 
         // Assert
         verify(mockedFileSystemAdapter).openInOperatingSystem(Path.of(APPLICATION_HOME_DIR));
+    }
+
+    @Test
+    void searchForFilesMatchingSearchText_searchesWithDateRange_whenSearchTextIsEmptyButDateFilterIsActive(FxRobot robot) {
+        // Arrange
+        var updatedFrom = LocalDate.of(2024, 6, 1);
+        var updatedTo = LocalDate.of(2024, 6, 30);
+        when(mockedDateRangeFilterPopup.isActive()).thenReturn(true);
+        when(mockedDateRangeFilterPopup.getSelectedFrom()).thenReturn(updatedFrom);
+        when(mockedDateRangeFilterPopup.getSelectedTo()).thenReturn(updatedTo);
+        when(mockedFulltextSearchService.findFilesWithNamesOrContentMatching(any(), any(), any())).thenReturn(Flux.empty());
+
+        // Act
+        sut.searchForFilesMatchingSearchText();
+
+        // Assert
+        verify(mockedFulltextSearchService).findFilesWithNamesOrContentMatching(any(), eq(updatedFrom), eq(updatedTo));
+    }
+
+    @Test
+    void searchForFilesMatchingSearchText_doesNotSearch_whenSearchTextIsEmptyAndDateFilterIsInactive(FxRobot robot) {
+        // Arrange
+        when(mockedDateRangeFilterPopup.isActive()).thenReturn(false);
+
+        // Act
+        sut.searchForFilesMatchingSearchText();
+
+        // Assert
+        verify(mockedFulltextSearchService, never()).findFilesWithNamesOrContentMatching(any(), any(), any());
     }
 }


### PR DESCRIPTION
Let users narrow search results to files last modified within a chosen date range, via quick presets (Today, Last 7 days, Last 30 days, This year) or a custom range, exposed through a new toolbar popover and a dismissible active-filter chip. Also works with an empty search box to browse all files modified in a given window.